### PR TITLE
Modified form to accept pre-defined YearTermID

### DIFF
--- a/OptionsWebsite/Controllers/ChoicesController.cs
+++ b/OptionsWebsite/Controllers/ChoicesController.cs
@@ -48,6 +48,30 @@ namespace OptionsWebsite.Controllers
             ViewBag.SecondChoiceOptionId = new SelectList(db.Options, "OptionID", "Title");
             ViewBag.ThirdChoiceOptionId = new SelectList(db.Options, "OptionID", "Title");
             ViewBag.YearTermID = new SelectList(db.YearTerms, "YearTermID", "YearTermID");
+
+            // Figure out what the name of the currently selected YearTerm is
+            var currentYearTerm = db.YearTerms.Where(c => c.isDefault == true).First();
+            var yearTermID = currentYearTerm.YearTermID;
+            var yearTermNum = currentYearTerm.Term;
+            var yearTermYear = currentYearTerm.Year;
+            var yearTermName = "";
+
+            switch(yearTermNum)
+            {
+                case 10:
+                    yearTermName = "Winter " + yearTermYear;
+                    break;
+                case 20:
+                    yearTermName = "Spring / Summer " + yearTermYear;
+                    break;
+                case 30:
+                    yearTermName = "Fall " + yearTermYear;
+                    break;
+            }
+
+            ViewBag.yearTermID = yearTermID;
+            ViewBag.yearTermName = yearTermName;
+
             return View();
         }
 

--- a/OptionsWebsite/Views/Choices/Create.cshtml
+++ b/OptionsWebsite/Views/Choices/Create.cshtml
@@ -12,16 +12,13 @@
     @Html.AntiForgeryToken()
 
     <div class="form-horizontal">
-        <h4>Choice</h4>
+        <h4>@ViewBag.yearTermName</h4>
         <hr />
         @Html.ValidationSummary(true, "", new { @class = "text-danger" })
-        <div class="form-group">
-            @Html.LabelFor(model => model.YearTermID, "YearTermID", htmlAttributes: new { @class = "control-label col-md-2" })
-            <div class="col-md-10">
-                @Html.EditorFor(model => model.YearTermID, new { htmlAttributes = new { @class = "form-control" } })
-                @Html.ValidationMessageFor(model => model.YearTermID, "", new { @class = "text-danger" })
-            </div>
-        </div>
+
+        @* Hidden field to store the YearTermID that SHOULD NOT be set by the user *@
+        @Html.Hidden("YearTermID", (int)ViewBag.yearTermID)
+        @Html.ValidationMessageFor(model => model.YearTermID, "", new { @class = "text-danger" })
 
         <div class="form-group">
             @Html.LabelFor(model => model.StudentID, htmlAttributes: new { @class = "control-label col-md-2" })


### PR DESCRIPTION
The ID is hidden for the YearTerm. Instead the user friendly name for the YearTerm is shown to the user.
